### PR TITLE
adicionando tempo para o deninho divulgar uma pessoa streamer

### DIFF
--- a/src/messageFeatures/startDivulgationTwitch.js
+++ b/src/messageFeatures/startDivulgationTwitch.js
@@ -1,3 +1,5 @@
+const streamersDivulgated = []
+
 const fs = require("fs");
 const https = require("https");
 
@@ -39,21 +41,25 @@ exports.startDivulgationTwitch = (client) => {
               streamerData.stream != null &&
               !streamersOn.get(streamer.name)
             ) {
-              streamersOn.set(streamer.name, streamerData);
-              client.channels.cache
-                .get("763505017944277003")
-                .send(
-                  "**" +
+              if (!streamersDivulgated.includes(streamer.name)){
+                addDivulgatedStreamer(streamer.name)
+                streamersOn.set(streamer.name, streamerData);
+                client.channels.cache
+                  .get("763505017944277003")
+                  .send(
+                    "**" +
                     streamer.name +
                     "**" +
                     " Está on! \n_" +
                     streamerData.stream.channel.status +
                     "_\nhttps://twitch.tv/" +
                     streamer.name
-                );
-            }
-            if (streamersOn.get(streamer.name) && streamerData.stream == null) {
-              streamersOn.delete(streamer.name);
+                  );
+              }
+              if (streamersOn.get(streamer.name) && streamerData.stream == null) {
+                streamersOn.delete(streamer.name);
+              }
+
             }
           });
         }
@@ -61,3 +67,18 @@ exports.startDivulgationTwitch = (client) => {
     });
   }, 20000);
 };
+
+function addDivulgatedStreamer(streamerName){
+  streamersDivulgated.push(streamerName)
+  setTimeout(() => {
+    removeItemOnce(streamersDivulgated, streamerName)
+  }, 300000)
+}
+
+function removeItemOnce(arr, value) {
+  var index = arr.indexOf(value);
+  if (index > -1) {
+    arr.splice(index, 1);
+  }
+  return arr;
+}


### PR DESCRIPTION
Agora, o deninho irá esperar um tempo para divulgar uma pessoa streamer X novamente. Isso é útil quando a pessoa tem que ficar abrindo e fechando a live várias vezes pra pegar as qualidades